### PR TITLE
Fix desktop app download link

### DIFF
--- a/src/services/downloadLink.ts
+++ b/src/services/downloadLink.ts
@@ -1,6 +1,7 @@
 export function getDesktopDownloadUrl(): string {
-  const repo = 'allen6131/project-tracker-client';
-  const base = `https://github.com/${repo}/releases/latest/download`;
+  const repo = process.env.REACT_APP_GITHUB_REPO || 'allen6131/project-tracker-client';
+  const base = `https://github.com/${repo}/releases/latest`;
+  const directBase = `${base}/download`;
 
   const ua = navigator.userAgent || '';
   const platform = navigator.platform || '';
@@ -9,18 +10,19 @@ export function getDesktopDownloadUrl(): string {
   const isMac = /Mac/i.test(platform) || /Macintosh|Mac OS X/i.test(ua);
   const isLinux = /Linux/i.test(platform) || (/X11/i.test(ua) && !isMac && !isWindows);
 
+  // Electron-builder artifactName: "${productName}-${os}.${ext}" where os in {win, mac, linux}
   if (isWindows) {
-    return `${base}/Project%20Tracker-windows.exe`;
+    return `${directBase}/Project%20Tracker-win.exe`;
   }
   if (isMac) {
-    return `${base}/Project%20Tracker-mac.dmg`;
+    return `${directBase}/Project%20Tracker-mac.dmg`;
   }
   if (isLinux) {
-    return `${base}/Project%20Tracker-linux.AppImage`;
+    return `${directBase}/Project%20Tracker-linux.AppImage`;
   }
 
   // Fallback to releases page if unknown
-  return `https://github.com/${repo}/releases/latest`;
+  return base;
 }
 
 export function getPlatformLabel(): string {


### PR DESCRIPTION
Fixes 404 for desktop app download by correcting Windows asset name and making GitHub repo configurable.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ad0a8cc-3f16-4a2f-9020-19c3e8bb0fc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ad0a8cc-3f16-4a2f-9020-19c3e8bb0fc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

